### PR TITLE
Add ESLint extension to JavaScript language module

### DIFF
--- a/modules/lang.javascript.sh
+++ b/modules/lang.javascript.sh
@@ -31,6 +31,7 @@ function as_user() {
     code-server --force --install-extension 'kavod-io.vscode-jest-test-adapter'
     code-server --force --install-extension 'hbenl.vscode-mocha-test-adapter'
     code-server --force --install-extension 'hbenl.vscode-jasmine-test-adapter'
+    code-server --force --install-extension 'dbaeumer.vscode-eslint'
 
     # Register the IJavaScript kernel
     ijsinstall


### PR DESCRIPTION
This adds ESLint support to properly lint JS/TS projects by default.