### PR TITLE
Disable LightDM by default

### DIFF
--- a/build/novnc.sh
+++ b/build/novnc.sh
@@ -63,6 +63,9 @@ pidfile="/run/\$RC_SVCNAME.pid"
 command_background="yes"
 EOT
     chmod +x /etc/init.d/novnc
+
+    # Disable LightDM so that it doesn't take over in privileged mode
+    rc-update del lightdm default
 else
     # Create systemd service for Xvfb
     cat <<EOT >/usr/lib/systemd/system/xvfb@.service
@@ -126,4 +129,6 @@ User=%i
 WantedBy=multi-user.target
 EOT
 
+    # Disable LightDM so that it doesn't take over in privileged mode
+    systemctl disable lightdm
 fi


### PR DESCRIPTION
This disables LightDM by default so that it can't take over X in privileged mode.