### PR TITLE
Ignore empty APT cache

### DIFF
--- a/configuration/apt.sh
+++ b/configuration/apt.sh
@@ -15,5 +15,5 @@ EOT
 # Refresh script
 function refresh() {
     # Remove cached packages
-    rm /var/cache/apt/archives/*.deb
+    rm -f /var/cache/apt/archives/*.deb
 }


### PR DESCRIPTION
This ignores an empty APT cache directory when refreshing the APT cache; this would otherwise fail if the user has not installed any DEB packages on top of the base image.